### PR TITLE
Convert Watch Demo button to YouTube link

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -69,9 +69,14 @@ export function Hero({ onGetStarted }: HeroProps) {
                 <ArrowRight className="ml-2 h-5 w-5" />
               </button>
               <div className="flex gap-4">
-                <button className="border-2 border-gray-300 text-gray-700 px-8 py-4 rounded-xl font-semibold hover:border-gray-400 transition-colors">
+                <a
+                  href="https://youtu.be/Q4V2p9eCSwY"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border-2 border-gray-300 text-gray-700 px-8 py-4 rounded-xl font-semibold hover:border-gray-400 transition-colors inline-flex items-center justify-center"
+                >
                   Watch Demo
-                </button>
+                </a>
                 <button
                   onClick={async () => {
                     try {


### PR DESCRIPTION
## Purpose
The user requested to redirect the "Watch Demo" button to a specific YouTube video (https://youtu.be/Q4V2p9eCSwY) when clicked, instead of having it function as a regular button.

## Code changes
- Converted the "Watch Demo" button from a `<button>` element to an `<a>` element
- Added `href` attribute pointing to the YouTube video URL
- Added `target="_blank"` to open the video in a new tab
- Added `rel="noopener noreferrer"` for security best practices
- Updated CSS classes to include `inline-flex items-center justify-center` to maintain the button's visual appearance and alignment

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cdbd0457d25a455e9fe2d9d30b84fdca/vibe-oasis)

👀 [Preview Link](https://cdbd0457d25a455e9fe2d9d30b84fdca-vibe-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cdbd0457d25a455e9fe2d9d30b84fdca</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->